### PR TITLE
Fix sourceMap: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var gobble = require( 'gobble' );
 module.exports = gobble( 'src' ).transform( 'coffee', options );
 ```
 
-The `options` argument, if specified, is passed to CoffeeScript. If you *don't* want to create sourcemaps, pass `sourceMaps: false`.
+The `options` argument, if specified, is passed to CoffeeScript. If you *don't* want to create sourcemaps, pass `sourceMap: false`.
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function coffee ( code, options ) {
 	compiled = require( 'coffee-script' ).compile( code, options );
 
 	return {
-		code: compiled.js,
+		code: options.sourceMap ? compiled.js : compiled,
 		map: compiled.v3SourceMap
 	};
 }


### PR DESCRIPTION
Fix `sourceMap: false` based on coffee-script 1.7.1. Also fix a typo in README.md.

https://github.com/jashkenas/coffeescript/blob/1.7.1/src/coffee-script.coffee#L76-82
